### PR TITLE
Fix `TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumMeta'`

### DIFF
--- a/pygui_macro/controller.py
+++ b/pygui_macro/controller.py
@@ -41,7 +41,7 @@ class Controller:
 
     @classmethod
     def key_release(cls, key):
-        if key in keyboard.Key:
+        if key in keyboard.Key.__dict__:
             cls.keyboard_controller.release(keyboard.Key[key])
         else:
             cls.keyboard_controller.release(key)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\Users\yaqub\PycharmProjects\pygui-macro\venv\Scripts\pygui-macro-script.py", line 33, in <module>
    sys.exit(load_entry_point('pygui-macro', 'console_scripts', 'pygui-macro')())
  File "c:\users\yaqub\pycharmprojects\pygui-macro\pygui_macro\pygui_macro.py", line 44, in main
    Runner(**kwargs).handle()
  File "c:\users\yaqub\pycharmprojects\pygui-macro\pygui_macro\runner.py", line 61, in handle
    self.actions[script[0]](*script[2:])
  File "c:\users\yaqub\pycharmprojects\pygui-macro\pygui_macro\controller.py", line 44, in key_release
    if key in keyboard.Key:
  File "C:\Users\yaqub\AppData\Local\Programs\Python\Python38\lib\enum.py", line 321, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumMeta'
```